### PR TITLE
Change uknown incoming call from null to unknown

### DIFF
--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -306,7 +306,11 @@ Notifications::NotificationItem::NotificationItem(const char* title,
       lv_obj_align(alert_caller, alert_subject, LV_ALIGN_OUT_BOTTOM_LEFT, 0, 0);
       lv_label_set_long_mode(alert_caller, LV_LABEL_LONG_BREAK);
       lv_obj_set_width(alert_caller, LV_HOR_RES - 20);
-      lv_label_set_text(alert_caller, msg);
+      if (strcmp(msg, "null") != 0) {
+        lv_label_set_text(alert_caller, msg);
+      } else {
+        lv_label_set_text(alert_caller, "Unknown");
+      }
 
       bt_accept = lv_btn_create(container, nullptr);
       bt_accept->user_data = this;


### PR DESCRIPTION
When using Gadgetbridge as a companion app, Infinitime shows that unknown call is coming from "null". 
This modification changes it to "Unknown"
![image](https://user-images.githubusercontent.com/52790629/185991649-1dbc2af3-56ad-496d-b6a9-cca175d29da3.png)
![image](https://user-images.githubusercontent.com/52790629/185991716-d6ff6794-2915-4fb2-8ab8-c14c1fc5b62c.png)
